### PR TITLE
docs: Fix Promise.then wrong parameter

### DIFF
--- a/aio/content/guide/zone.md
+++ b/aio/content/guide/zone.md
@@ -86,7 +86,7 @@ To clarify how changes are detected and values updated, consider the following c
       value = v;
       // call detectChange manually
       detectChange();
-    }, 100);
+    });
 
     // Example 5: some other asynchronous APIs
     document.getElementById('canvas').toBlob(blob =&gt; {


### PR DESCRIPTION
Removed the second wrong parameter from the `Promise.then()` method in the doc.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/angular/angular/blob/main/CONTRIBUTING.md#commit
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #51320

